### PR TITLE
IBX-88: Overridden debug:config command to use custom ContainerBuilder & restored ezplatform BC

### DIFF
--- a/src/bundle/Command/BuildDebugContainerTrait.php
+++ b/src/bundle/Command/BuildDebugContainerTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\CompatibilityLayer\Command;
+
+use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @internal
+ *
+ * @see \Symfony\Bundle\FrameworkBundle\Command\BuildDebugContainerTrait
+ */
+trait BuildDebugContainerTrait
+{
+    protected $containerBuilder;
+
+    /**
+     * Loads the ContainerBuilder from the cache.
+     *
+     * @throws \LogicException|\Exception
+     */
+    protected function getContainerBuilder(KernelInterface $kernel): SymfonyContainerBuilder
+    {
+        if ($this->containerBuilder) {
+            return $this->containerBuilder;
+        }
+
+        if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
+            $buildContainer = \Closure::bind(function () {
+                $this->initializeBundles();
+
+                return $this->buildContainer();
+            }, $kernel, \get_class($kernel));
+            $container = $buildContainer();
+            $container->getCompilerPassConfig()->setRemovingPasses([]);
+            $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+            $container->compile();
+        } else {
+            (new XmlFileLoader($container = new ContainerBuilder(), new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
+            $locatorPass = new ServiceLocatorTagPass();
+            $locatorPass->process($container);
+        }
+
+        return $this->containerBuilder = $container;
+    }
+}

--- a/src/bundle/Command/SymfonyConfigDebugCommand.php
+++ b/src/bundle/Command/SymfonyConfigDebugCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\CompatibilityLayer\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand;
+
+/**
+ * @see \Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand
+ */
+class SymfonyConfigDebugCommand extends ConfigDebugCommand
+{
+    use BuildDebugContainerTrait;
+
+    protected static $defaultName = 'debug:config';
+}

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -8,3 +8,5 @@ services:
         decorates: 'event_dispatcher'
         arguments:
             $innerEventDispatcher: '@.inner'
+
+    Ibexa\Bundle\CompatibilityLayer\Command\SymfonyConfigDebugCommand: ~


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-88](https://issues.ibexa.co/browse/IBX-88)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

This PR replaces Symfony `debug:config` command to be able to inject our own version of `\Symfony\Bundle\FrameworkBundle\Command\BuildDebugContainerTrait` which [hardcodes `ContainerBuilder` usage](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php#L53). To be able to properly debug all extensions which use legacy names (both 1st party and 3rd party), we need to inject there our custom Ibexa Container Builder introduced via #3.

The only alternative way of overriding container builder there is via nasty Reflection usage: https://gist.github.com/alongosz/1a30cf7a2a8b30eb0f6806f68e972d2f. It produces less code, but is quite unclean.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // requires rather full stack coverage like Behat, so rather not worth it in the broader context
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.