### PR TITLE
IBX-1589: Provided BC layer for all Ibexa Symfony Extension names

### DIFF
--- a/src/bundle/Command/SymfonyConfigDumpReferenceCommand.php
+++ b/src/bundle/Command/SymfonyConfigDumpReferenceCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\CompatibilityLayer\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand;
+
+class SymfonyConfigDumpReferenceCommand extends ConfigDumpReferenceCommand
+{
+    use BuildDebugContainerTrait;
+
+    protected static $defaultName = 'config:dump-reference';
+}

--- a/src/bundle/DependencyInjection/ContainerBuilder.php
+++ b/src/bundle/DependencyInjection/ContainerBuilder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\CompatibilityLayer\DependencyInjection;
 
+use Ibexa\Bundle\CompatibilityLayer\IbexaCompatibilityLayerBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
@@ -16,10 +17,8 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
  */
 final class ContainerBuilder extends SymfonyContainerBuilder
 {
-    public const EXTENSION_NAME_BC_MAP = [
-        'ezpublish' => 'ibexa',
-        'ezplatform' => 'ibexa',
-    ];
+    /** @var array<string, string> */
+    private static $extensionNameMap;
 
     public function hasExtension(string $name): bool
     {
@@ -52,6 +51,12 @@ final class ContainerBuilder extends SymfonyContainerBuilder
 
     private function resolveExtensionName(string $name): string
     {
-        return self::EXTENSION_NAME_BC_MAP[$name] ?? $name;
+        if (!isset(self::$extensionNameMap)) {
+            /** @noinspection PhpIncludeInspection */
+            self::$extensionNameMap = require IbexaCompatibilityLayerBundle::MAPPINGS_PATH
+                . \DIRECTORY_SEPARATOR . 'symfony-extension-name-map.php';
+        }
+
+        return self::$extensionNameMap[$name] ?? $name;
     }
 }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -10,3 +10,5 @@ services:
             $innerEventDispatcher: '@.inner'
 
     Ibexa\Bundle\CompatibilityLayer\Command\SymfonyConfigDebugCommand: ~
+
+    Ibexa\Bundle\CompatibilityLayer\Command\SymfonyConfigDumpReferenceCommand: ~

--- a/src/bundle/Resources/mappings/symfony-extension-name-map.php
+++ b/src/bundle/Resources/mappings/symfony-extension-name-map.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+return [
+    'ezpublish' => 'ibexa',
+    'ezplatform' => 'ibexa',
+    'ezdesign' => 'ibexa_design_engine',
+    'ez_doctrine_schema' => 'ibexa_doctrine_schema',
+    'ez_io' => 'ibexa_io',
+    'ezplatform_elastic_search_engine' => 'ibexa_elasticsearch',
+    'ez_platform_fastly_cache' => 'ibexa_fastly',
+    'ezplatform_form_builder' => 'ibexa_form_builder',
+    'ezplatform_graphql' => 'ibexa_graphql',
+    'ez_platform_http_cache' => 'ibexa_http_cache',
+    'ez_platform_page_builder' => 'ibexa_page_builder',
+    'ezplatform_page_fieldtype' => 'ibexa_fieldtype_page',
+    'ez_platform_standard_design' => 'ibexa_standard_design',
+    'ezplatform_support_tools' => 'ibexa_system_info',
+    'ezrecommendation' => 'ibexa_personalization_client',
+    'ezrichtext' => 'ibexa_fieldtype_richtext',
+    'ez_search_engine_legacy' => 'ibexa_legacy_search_engine',
+    'ez_search_engine_solr' => 'ibexa_solr',
+    'ibexa_platform_commerce_field_types' => 'ibexa_commerce_field_types',
+    'one_sky' => 'ibexa_commerce_one_sky',
+    'ses_specificationstypefieldtype' => 'ibexa_commerce_specifications_type',
+    'shop_price_engine_plugin' => 'ibexa_commerce_price_engine',
+    'silversolutions_eshop' => 'ibexa_commerce_eshop',
+    'silversolutions_tools' => 'ibexa_commerce_shop_tools',
+    'silversolutions_translation' => 'ibexa_commerce_translation',
+    'siso_admin_erp' => 'ibexa_commerce_erp_admin',
+    'siso_basket' => 'ibexa_commerce_basket',
+    'siso_checkout' => 'ibexa_commerce_checkout',
+    'siso_comparison' => 'ibexa_commerce_comparison',
+    'siso_content_plugin' => 'ibexa_commerce_base_design',
+    'siso_ez_studio' => 'ibexa_commerce_ez_studio',
+    'siso_local_order_management' => 'ibexa_commerce_local_order_management',
+    'siso_newsletter' => 'ibexa_commerce_newsletter',
+    'siso_order_history' => 'ibexa_commerce_order_history',
+    'siso_payment' => 'ibexa_commerce_payment',
+    'siso_price' => 'ibexa_commerce_price',
+    'siso_quick_order' => 'ibexa_commerce_quick_order',
+    'siso_search' => 'ibexa_commerce_search',
+    'siso_shop_frontend' => 'ibexa_commerce_shop_frontend',
+    'siso_test' => 'ibexa_commerce_test_tools',
+    'siso_tools' => 'ibexa_commerce_tools',
+];

--- a/src/bundle/Resources/mappings/symfony-extension-name-map.php
+++ b/src/bundle/Resources/mappings/symfony-extension-name-map.php
@@ -25,6 +25,7 @@ return [
     'ezrichtext' => 'ibexa_fieldtype_richtext',
     'ez_search_engine_legacy' => 'ibexa_legacy_search_engine',
     'ez_search_engine_solr' => 'ibexa_solr',
+    'ezplatform_site_factory' => 'ibexa_site_factory',
     'ibexa_platform_commerce_field_types' => 'ibexa_commerce_field_types',
     'one_sky' => 'ibexa_commerce_one_sky',
     'ses_specificationstypefieldtype' => 'ibexa_commerce_specifications_type',

--- a/src/bundle/Resources/mappings/symfony-extension-name-map.php
+++ b/src/bundle/Resources/mappings/symfony-extension-name-map.php
@@ -23,8 +23,11 @@ return [
     'ezplatform_support_tools' => 'ibexa_system_info',
     'ezrecommendation' => 'ibexa_personalization_client',
     'ezrichtext' => 'ibexa_fieldtype_richtext',
+    'ez_platform_version_comparison' => 'ibexa_version_comparison',
+    'ez_publish_rest' => 'ibexa_rest',
     'ez_search_engine_legacy' => 'ibexa_legacy_search_engine',
     'ez_search_engine_solr' => 'ibexa_solr',
+    'ez_systems_date_based_publisher' => 'ibexa_scheduler',
     'ezplatform_site_factory' => 'ibexa_site_factory',
     'ibexa_platform_commerce_field_types' => 'ibexa_commerce_field_types',
     'one_sky' => 'ibexa_commerce_one_sky',
@@ -49,4 +52,5 @@ return [
     'siso_shop_frontend' => 'ibexa_commerce_shop_frontend',
     'siso_test' => 'ibexa_commerce_test_tools',
     'siso_tools' => 'ibexa_commerce_tools',
+    'siso_voucher' => 'ibexa_commerce_voucher',
 ];


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

This PR:
- [x] Extracts existing extension name map to a separate file, following existing convention
- [x] Updates that map according to [IBX-1589](https://issues.ibexa.co/browse/IBX-1589) specification
- [x] Overrides `config:dump-reference` command, similar as in case of #4, for the same reasons

### Documentation

Upgrade process: change project references to old extension names, name map available in [IBX-1589](https://issues.ibexa.co/browse/IBX-1589) - should be moved to doc as well.

### TODO
- [x] Make Pull Requests renaming each extension & config TreeBuilder root name

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // already there
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
