### PR TITLE
IBX-1210: Implemented BC layer for ezdesign

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "require-dev": {
         "symfony/var-dumper": "^5.0",
         "ibexa/code-style": "^1.0",
+        "ibexa/design-engine": "^4.0@dev",
+        "ibexa/core": "^4.0@dev",
+        "ibexa/doctrine-schema": "^4.0@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "phpunit/phpunit":  "^9.5.10",
         "phpstan/phpstan": "^0.12.99"

--- a/src/bundle/DependencyInjection/Compiler/AssetThemeCompatibilityPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AssetThemeCompatibilityPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler;
+
+use Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class AssetThemeCompatibilityPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container
+            ->findDefinition('assets.packages')
+            ->addMethodCall(
+                'addPackage',
+                [
+                    LegacyDesignThemeTemplateNameResolver::DESIGN_NAMESPACE,
+                    $container->findDefinition('ezdesign.asset_theme_package'),
+                ]
+            );
+    }
+}

--- a/src/bundle/IbexaCompatibilityLayerBundle.php
+++ b/src/bundle/IbexaCompatibilityLayerBundle.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\CompatibilityLayer;
 
 use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler\AliasDecoratorCompatibilityPass;
+use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler\AssetThemeCompatibilityPass;
 use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler\FormTypeExtensionCompatibilityPass;
 use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler\ServiceCompatibilityPass;
 use Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler\TwigPass;
@@ -69,6 +70,12 @@ final class IbexaCompatibilityLayerBundle extends Bundle
             new TwigPass($bundleNameResolver),
             PassConfig::TYPE_BEFORE_OPTIMIZATION,
             5 //Run after Twig one
+        );
+
+        $container->addCompilerPass(
+            new AssetThemeCompatibilityPass(),
+            PassConfig::TYPE_OPTIMIZE,
+            -1
         );
     }
 }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -14,3 +14,13 @@ services:
     Ibexa\Bundle\CompatibilityLayer\Command\SymfonyConfigDumpReferenceCommand: ~
 
     Ibexa\Bundle\CompatibilityLayer\Command\IbexaRebrandingCommand: ~
+
+    Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver: ~
+
+    ibexa.compatibility.design_engine.legacy_twig_theme_loader:
+        class: Ibexa\DesignEngine\Templating\Twig\TwigThemeLoader
+        public: false
+        arguments:
+            $templateNameResolver: '@Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver'
+            $templatePathRegistry: '@ezdesign.template_path_registry'
+            $innerFilesystemLoader: '@twig.loader.filesystem'

--- a/src/bundle/Resources/mappings/class-map.php
+++ b/src/bundle/Resources/mappings/class-map.php
@@ -165,6 +165,7 @@ return [
   'EzSystems\\DateBasedPublisherBundle\\DependencyInjection\\EzSystemsDateBasedPublisherExtension' => 'Ibexa\\Bundle\\Scheduler\\DependencyInjection\\IbexaSchedulerExtension',
   'EzSystems\\EzPlatformDesignEngineBundle\\EzPlatformDesignEngineBundle' => 'Ibexa\\Bundle\\DesignEngine\\IbexaDesignEngineBundle',
   'EzSystems\\EzPlatformDesignEngineBundle\\DependencyInjection\\EzPlatformDesignEngineExtension' => 'Ibexa\\Bundle\\DesignEngine\\DependencyInjection\\IbexaDesignEngineExtension',
+  'EzSystems\\EzPlatformDesignEngine\\DesignAwareInterface' => 'Ibexa\\Contracts\\DesignEngine\\DesignAwareInterface',
   'EzSystems\\DoctrineSchema\\API\\Exception\\InvalidConfigurationException' => 'Ibexa\\Contracts\\DoctrineSchema\\Exception\\InvalidConfigurationException',
   'EzSystems\\DoctrineSchema\\API\\Event\\SchemaBuilderEvent' => 'Ibexa\\Contracts\\DoctrineSchema\\Event\\SchemaBuilderEvent',
   'EzSystems\\DoctrineSchema\\API\\Event\\SchemaBuilderEvents' => 'Ibexa\\Contracts\\DoctrineSchema\\SchemaBuilderEvents',

--- a/src/bundle/Twig/LegacyDesignThemeTemplateNameResolver.php
+++ b/src/bundle/Twig/LegacyDesignThemeTemplateNameResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\CompatibilityLayer\Twig;
+
+use Ibexa\DesignEngine\Templating\ThemeTemplateNameResolver;
+
+class LegacyDesignThemeTemplateNameResolver extends ThemeTemplateNameResolver
+{
+    public const DESIGN_NAMESPACE = 'ezdesign';
+}

--- a/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
+++ b/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\CompatibilityLayer\Twig;
+
+use Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver;
+use Ibexa\Core\MVC\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LegacyDesignThemeTemplateNameResolverTest extends TestCase
+{
+    private const LEGACY_DESIGN = 'ezdesign';
+    private const SITE_DESIGN = 'site';
+
+    private LegacyDesignThemeTemplateNameResolver $templateNameResolver;
+
+    protected function setUp(): void
+    {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $configResolverMock
+            ->method('getParameter')
+            ->with('design')
+            ->willReturn(self::SITE_DESIGN);
+
+        $this->templateNameResolver = new LegacyDesignThemeTemplateNameResolver(
+            $configResolverMock
+        );
+    }
+
+    /**
+     * @dataProvider getDataForTestIsTemplateDesignNamespaced
+     */
+    public function testIsTemplateDesignNamespaced(string $name, bool $expectedIsNamespaced): void
+    {
+        self::assertSame(
+            $expectedIsNamespaced,
+            $this->templateNameResolver->isTemplateDesignNamespaced($name)
+        );
+
+    }
+
+    public function getDataForTestIsTemplateDesignNamespaced(): iterable
+    {
+        yield self::LEGACY_DESIGN => [
+            '@' . self::LEGACY_DESIGN . '/foo.html.twig',
+            true,
+        ];
+
+        yield self::SITE_DESIGN => [
+            '@' . self::SITE_DESIGN . '/bar.html.twig',
+            true,
+        ];
+
+        yield 'foo' => [
+            '@foo/bar.html.twig',
+            false,
+        ];
+    }
+}

--- a/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
+++ b/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
@@ -41,7 +41,6 @@ final class LegacyDesignThemeTemplateNameResolverTest extends TestCase
             $expectedIsNamespaced,
             $this->templateNameResolver->isTemplateDesignNamespaced($name)
         );
-
     }
 
     public function getDataForTestIsTemplateDesignNamespaced(): iterable


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1210](https://issues.ibexa.co/browse/IBX-1210)
| **Requires**                             |
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

This PR provides compatibility layer for:
- [x] `ezdesign` Twig namespace
- [x] `ezdesign` Symfony Asset package name

Additionaly the class `'EzSystems\EzPlatformDesignEngine\DesignAwareInterface` has been moved to `Ibexa\Contracts\DesignEngine\DesignAwareInterface`


### Open questions
- [ ] Is it clean to add `ibexa/*` dependencies? They should be even in the Composer `require` section for source code integrity, but for now placed them in the `require-dev` section as they're needed for automated test coverage purposes.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Asked for a review.
