### PR TITLE
Fixed `ezdesign.asset_theme_package` service sometimes not available

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/AssetThemeCompatibilityPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AssetThemeCompatibilityPass.php
@@ -11,6 +11,7 @@ namespace Ibexa\Bundle\CompatibilityLayer\DependencyInjection\Compiler;
 use Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * @internal
@@ -19,13 +20,19 @@ final class AssetThemeCompatibilityPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        try {
+            $definition = $container->findDefinition('ezdesign.asset_theme_package');
+        } catch (ServiceNotFoundException $e) {
+            return;
+        }
+
         $container
             ->findDefinition('assets.packages')
             ->addMethodCall(
                 'addPackage',
                 [
                     LegacyDesignThemeTemplateNameResolver::DESIGN_NAMESPACE,
-                    $container->findDefinition('ezdesign.asset_theme_package'),
+                    $definition,
                 ]
             );
     }


### PR DESCRIPTION
In some cases, especially in integration tests with limited bundles enabled, service that is subject of the `CompilerPass` that is adjusted in this PR does not exist, causing container compilation to fail.