### PR TITLE
Fixed replacing single colon with double one as it messup with exact match in viewfilters/builders

### DIFF
--- a/src/lib/HttpKernel/Controller/ControllerResolver.php
+++ b/src/lib/HttpKernel/Controller/ControllerResolver.php
@@ -58,17 +58,22 @@ class ControllerResolver implements ControllerResolverInterface
             return $this->controllerResolver->getController($request);
         }
 
-        if (1 === substr_count($controller, ':')) {
-            $controller = str_replace(':', '::', $controller);
-        }
         $method = null;
+        $separator = '';
         if (str_contains($controller, '::')) {
-            [$class, $method] = explode('::', $controller, 2);
+            $separator = '::';
+        } elseif (str_contains($controller, ':')) {
+            $separator = ':';
+        }
+
+        if ($separator !== '') {
+            [$class, $method] = explode($separator, $controller, 2);
         } else {
             $class = $controller;
         }
+
         $newName = $this->getNewControllerName($class);
-        $controller = implode('::', $method ? [$newName, $method] : [$newName]);
+        $controller = implode($separator, $method ? [$newName, $method] : [$newName]);
         $request->attributes->set('_controller', $controller);
 
         return $this->controllerResolver->getController($request);

--- a/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
+++ b/tests/bundle/Twig/LegacyDesignThemeTemplateNameResolverTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Bundle\CompatibilityLayer\Twig;
 
 use Ibexa\Bundle\CompatibilityLayer\Twig\LegacyDesignThemeTemplateNameResolver;
-use Ibexa\Core\MVC\ConfigResolverInterface;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use PHPUnit\Framework\TestCase;
 
 final class LegacyDesignThemeTemplateNameResolverTest extends TestCase


### PR DESCRIPTION
Note:

We will have to deal with that in the feature, as single colon is deprecated since symfony 5.1 when reffering to a controller, but all of our view filters/builders match on exact string, as in:
```php
    public function matches($argument)
    {
        return 'ibexa_content_edit:createWithoutDraftAction' === $argument;
    }
```