### PR TITLE
IBX-1696: Used ibexa.url_wildcards.enabled parameter with the fallback

### DIFF
--- a/src/bundle/DependencyInjection/IbexaCompatibilityLayerExtension.php
+++ b/src/bundle/DependencyInjection/IbexaCompatibilityLayerExtension.php
@@ -30,9 +30,18 @@ final class IbexaCompatibilityLayerExtension extends Extension implements Prepen
 
         $loader->load('services.yaml');
 
-        if ($container->getParameter('ezpublish.url_wildcards.enabled')) {
+        if ($this->areUrlWildcardsEnabled($container)) {
             $loader->load('conditional/url_wildcard.yaml');
         }
+    }
+
+    private function areUrlWildcardsEnabled(ContainerBuilder $container): bool
+    {
+        if ($container->hasParameter('ibexa.url_wildcards.enabled')) {
+            return $container->getParameter('ibexa.url_wildcards.enabled');
+        }
+
+        return $container->getParameter('ezpublish.url_wildcards.enabled');
     }
 
     public function prepend(ContainerBuilder $container): void


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

`ezpublish.url_wildcards.enabled` is now used as a fallback only.