### PR TITLE
IBX-1696: Implemented BC layer for Config Resolver namespaces

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -51,3 +51,8 @@ services:
         decorates: controller_resolver
         arguments:
             $controllerResolver: '@Ibexa\CompatibilityLayer\HttpKernel\Controller\ControllerResolver.inner'
+
+    Ibexa\CompatibilityLayer\ConfigResolver\BackwardCompatibleConfigResolver:
+        decorates: Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver
+        arguments:
+            $chainConfigResolver: '@.inner'

--- a/src/bundle/Resources/mappings/config-resolver-namespaces-map.php
+++ b/src/bundle/Resources/mappings/config-resolver-namespaces-map.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+return [
+    'ezsettings' => 'ibexa.site_access.config',
+    'ezrecommendation' => 'ibexa.personalization.site_access.config',
+    'ses_basket' => 'ibexa.commerce.site_access.config.basket',
+    'siso_basket' => 'ibexa.commerce.site_access.config.basket',
+    'ses_stored_basket' => 'ibexa.commerce.site_access.config.basket.stored',
+    'ses_eshop' => 'ibexa.commerce.site_access.config.eshop',
+    'silver_eshop' => 'ibexa.commerce.site_access.config.eshop',
+    'ses_forms' => 'ibexa.commerce.site_access.config.forms',
+    'ses_wishlist' => 'ibexa.commerce.site_access.config.wishlist',
+    'silver_content' => 'ibexa.commerce.site_access.config.content',
+    'silver_econtent' => 'ibexa.commerce.site_access.config.econtent',
+    'siso_checkout' => 'ibexa.commerce.site_access.config.checkout',
+    'siso_control_center' => 'ibexa.commerce.site_access.config.control_center',
+    'siso_comparison' => 'ibexa.commerce.site_access.config.comparison',
+    'siso_core' => 'ibexa.commerce.site_access.config.core',
+    'siso_datatypes' => 'ibexa.commerce.site_access.config.data_types',
+    'siso_erp' => 'ibexa.commerce.site_access.config.erp',
+    'siso_local_order_management' => 'ibexa.commerce.site_access.config.order.management.local',
+    'siso_newsletter' => 'ibexa.commerce.site_access.config.newsletter',
+    'siso_order_history' => 'ibexa.commerce.site_access.config.order.history',
+    'siso_pattern_zip' => 'ibexa.commerce.site_access.config.zip',
+    'siso_price' => 'ibexa.commerce.site_access.config.price',
+    'siso_quickorder' => 'ibexa.commerce.site_access.config.quick_order',
+    'siso_rest' => 'ibexa.commerce.site_access.config.rest',
+    'siso_search' => 'ibexa.commerce.site_access.config.search',
+    'siso_seo' => 'ibexa.commerce.site_access.config.seo',
+    'siso_tools' => 'ibexa.commerce.site_access.config.tools',
+    'silver_tools' => 'ibexa.commerce.site_access.config.tools',
+    'siso_voucher' => 'ibexa.commerce.site_access.config.voucher',
+    'st_ez_helper_create_user' => 'ibexa.commerce.site_access.config.create_user',
+];

--- a/src/lib/ConfigResolver/BackwardCompatibleConfigResolver.php
+++ b/src/lib/ConfigResolver/BackwardCompatibleConfigResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CompatibilityLayer\ConfigResolver;
+
+use Ibexa\Bundle\CompatibilityLayer\IbexaCompatibilityLayerBundle;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
+/**
+ * Maps legacy namespace to the new one, but only if the parameter in the old namespace is not defined.
+ * Explicit old definition may come from a custom project configuration.
+ *
+ * @internal
+ */
+final class BackwardCompatibleConfigResolver implements ConfigResolverInterface
+{
+    public const LEGACY_DEFAULT_NAMESPACE = 'ezsettings';
+
+    private ConfigResolverInterface $chainConfigResolver;
+
+    /** @var array<string, string */
+    private array $configResolverNamespacesMap;
+
+    public function __construct(ConfigResolverInterface $chainConfigResolver)
+    {
+        $this->chainConfigResolver = $chainConfigResolver;
+        $this->configResolverNamespacesMap = require IbexaCompatibilityLayerBundle::MAPPINGS_PATH . '/config-resolver-namespaces-map.php';
+    }
+
+    public function getParameter(
+        string $paramName,
+        ?string $namespace = null,
+        ?string $scope = null
+    ) {
+        if ($this->chainConfigResolver->hasParameter($paramName, $namespace, $scope)) {
+            return $this->chainConfigResolver->getParameter($paramName, $namespace, $scope);
+        }
+        $namespace ??= self::LEGACY_DEFAULT_NAMESPACE;
+        if ($this->chainConfigResolver->hasParameter($paramName, $namespace, $scope)) {
+            return $this->chainConfigResolver->getParameter($paramName, $namespace, $scope);
+        }
+
+        return $this->chainConfigResolver->getParameter(
+            $paramName,
+            $this->configResolverNamespacesMap[$namespace] ?? $namespace,
+            $scope
+        );
+    }
+
+    public function hasParameter(
+        string $paramName,
+        ?string $namespace = null,
+        ?string $scope = null
+    ): bool {
+        $resolvedNamespace = $this->configResolverNamespacesMap[$namespace] ?? $namespace;
+        if (
+            isset($this->configResolverNamespacesMap[$namespace]) &&
+            true === $this->chainConfigResolver->hasParameter($paramName, $namespace, $scope)
+        ) {
+            return true;
+        }
+
+        return $this->chainConfigResolver->hasParameter($paramName, $resolvedNamespace, $scope);
+    }
+
+    public function setDefaultNamespace(string $defaultNamespace): void
+    {
+        $this->chainConfigResolver->setDefaultNamespace($defaultNamespace);
+    }
+
+    public function getDefaultNamespace(): string
+    {
+        return $this->chainConfigResolver->getDefaultNamespace();
+    }
+}

--- a/tests/lib/ConfigResolver/BackwardCompatibleConfigResolverTest.php
+++ b/tests/lib/ConfigResolver/BackwardCompatibleConfigResolverTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\CompatibilityLayer\ConfigResolver;
+
+use Ibexa\CompatibilityLayer\ConfigResolver\BackwardCompatibleConfigResolver;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class BackwardCompatibleConfigResolverTest extends TestCase
+{
+    /**
+     * See ./src/bundle/Resources/mappings/config-resolver-namespaces-map.php for the full map.
+     */
+    private const NAMESPACE_MAP = [
+        'ezsettings' => 'ibexa.site_access.config',
+        'ses_wishlist' => 'ibexa.commerce.site_access.config.wishlist',
+    ];
+
+    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private MockObject $chainConfigResolverMock;
+
+    private BackwardCompatibleConfigResolver $resolver;
+
+    public function getDataForTestGetParameter(): iterable
+    {
+        yield 'description_limit for a default scope in the ses_wishlist namespace' => [
+            'description_limit',
+            'ses_wishlist',
+            null,
+            '50',
+        ];
+
+        yield 'page_layout for a default scope in a default namespace' => [
+            'page_layout',
+            null,
+            null,
+            'page_layout.html.twig',
+        ];
+
+        yield 'location_view for a default scope in the ezsettings namespace' => [
+            'location_view',
+            'ezsettings',
+            null,
+            'location_view.html.twig',
+        ];
+
+        yield 'page_layout for an admin scope in a default namespace' => [
+            'page_layout',
+            null,
+            'admin',
+            'page_layout.html.twig',
+        ];
+
+        yield 'page_layout for an admin_group scope in the ezsettings namespace' => [
+            'page_layout',
+            'ezsettings',
+            'admin_group',
+            'page_layout.html.twig',
+        ];
+
+        yield 'page_layout for a site scope in the ibexa.site_access.config namespace' => [
+            'page_layout',
+            'ibexa.site_access.config',
+            'site',
+            'page_layout.html.twig',
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->chainConfigResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $this->resolver = new BackwardCompatibleConfigResolver($this->chainConfigResolverMock);
+    }
+
+    /**
+     * @dataProvider getDataForTestGetParameter
+     */
+    public function testGetParameter(
+        string $parameterName,
+        ?string $namespace,
+        ?string $scope,
+        string $expectedValue
+    ): void {
+        $this->configureInnerResolver($parameterName, $namespace, $scope, $expectedValue);
+
+        self::assertSame(
+            $expectedValue,
+            $this->resolver->getParameter($parameterName, $namespace, $scope)
+        );
+    }
+
+    /**
+     * @dataProvider getDataForTestGetParameter
+     */
+    public function testHasParameter(
+        string $parameterName,
+        ?string $namespace,
+        ?string $scope
+    ): void {
+        $this
+            ->chainConfigResolverMock
+            ->method('hasParameter')
+            ->with($parameterName, $namespace, $scope)
+            ->willReturn(true);
+
+        self::assertTrue($this->resolver->hasParameter($parameterName, $namespace, $scope));
+    }
+
+    private function configureInnerResolver(
+        string $parameterName,
+        ?string $namespace,
+        ?string $scope,
+        string $expectedValue
+    ): void {
+        $resolvedNamespace = self::NAMESPACE_MAP[$namespace] ?? $namespace;
+        $isNewNamespace = $namespace === $resolvedNamespace;
+        // "hasParameter" call should return false for legacy namespaces and true for the new ones
+        $this
+            ->chainConfigResolverMock
+            ->method('hasParameter')
+            ->with($parameterName, $namespace, $scope)
+            ->willReturn($isNewNamespace);
+
+        $this
+            ->chainConfigResolverMock
+            ->method('getParameter')
+            ->with($parameterName, $resolvedNamespace, $scope)
+            ->willReturn($expectedValue);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

This PR adds decorator for chained config resolver, which substitutes legacy namespace with a new one if needed.
The logic is as follows:
1. If a parameter exists in an explicit or implicit default namespace - return it
2. If a parameter exists in the legacy default `ezsettings` namespace - return it
3. If a parameter exists in the new namespace according to the map - return it

This covers following use cases:

- Fetching custom parameter defined in `ezsettings`
- Fetching Product parameter through `ezsettings` namespace (implicit or explicit)
- Fetching Product parameter through any explicit Commerce namespace

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review