### PR TITLE
Removed ez_recommendation.content_type.get_content_type from deprecated route config

### DIFF
--- a/src/bundle/Resources/config/deprecated_routing_content.yaml
+++ b/src/bundle/Resources/config/deprecated_routing_content.yaml
@@ -115,12 +115,6 @@ ez_recommendation.content_type.get_content:
         package: ibexa/personalization
         version: 4.0.0
 
-ez_recommendation.content_type.get_content_type:
-    alias: ibexa.personalization.content_type.get_content_type
-    deprecated:
-        package: ibexa/personalization
-        version: 4.0.0
-
 ez_recommendation.export.download:
     alias: ibexa.personalization.export.download
     deprecated:


### PR DESCRIPTION
Route `ez_recommendation.content_type.get_content_type` has been dropped here: https://github.com/ibexa/personalization/pull/117/files