### PR TITLE
IBX-5929: Added `RoutingListener` to properly set parameters for `UrlAliasRouter`

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -64,3 +64,11 @@ services:
         decorates: Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver
         arguments:
             $chainConfigResolver: '@.inner'
+
+    Ibexa\CompatibilityLayer\Event\Subscriber\RoutingListener:
+        arguments:
+            $configResolver: '@ibexa.config.resolver'
+            $urlAliasRouter: '@Ibexa\CompatibilityLayer\Routing\UrlAliasRouter'
+            $urlAliasGenerator: '@Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/lib/Event/Subscriber/RoutingListener.php
+++ b/src/lib/Event/Subscriber/RoutingListener.php
@@ -8,45 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\CompatibilityLayer\Event\Subscriber;
 
-use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
-use Ibexa\Core\MVC\Symfony\MVCEvents;
-use Ibexa\Core\MVC\Symfony\Routing\Generator;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Routing\RouterInterface;
+use Ibexa\Bundle\Core\EventListener\RoutingListener as CoreRoutingListener;
 
-class RoutingListener implements EventSubscriberInterface
+class RoutingListener extends CoreRoutingListener
 {
-    private ConfigResolverInterface $configResolver;
-
-    private RouterInterface $urlAliasRouter;
-
-    private Generator $urlAliasGenerator;
-
-    public function __construct(
-        ConfigResolverInterface $configResolver,
-        RouterInterface $urlAliasRouter,
-        Generator $urlAliasGenerator
-    ) {
-        $this->configResolver = $configResolver;
-        $this->urlAliasRouter = $urlAliasRouter;
-        $this->urlAliasGenerator = $urlAliasGenerator;
-    }
-
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            MVCEvents::SITEACCESS => ['onSiteAccessMatch', 200],
-        ];
-    }
-
-    public function onSiteAccessMatch(PostSiteAccessMatchEvent $event): void
-    {
-        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id');
-        $this->urlAliasRouter->setRootLocationId($rootLocationId);
-        $this->urlAliasGenerator->setRootLocationId($rootLocationId);
-        $this->urlAliasGenerator->setExcludedUriPrefixes(
-            $this->configResolver->getParameter('content.tree_root.excluded_uri_prefixes')
-        );
-    }
 }

--- a/src/lib/Event/Subscriber/RoutingListener.php
+++ b/src/lib/Event/Subscriber/RoutingListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CompatibilityLayer\Event\Subscriber;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
+use Ibexa\Core\MVC\Symfony\Routing\Generator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class RoutingListener implements EventSubscriberInterface
+{
+    private ConfigResolverInterface $configResolver;
+
+    private RouterInterface $urlAliasRouter;
+
+    private Generator $urlAliasGenerator;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        RouterInterface $urlAliasRouter,
+        Generator $urlAliasGenerator
+    ) {
+        $this->configResolver = $configResolver;
+        $this->urlAliasRouter = $urlAliasRouter;
+        $this->urlAliasGenerator = $urlAliasGenerator;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MVCEvents::SITEACCESS => ['onSiteAccessMatch', 200],
+        ];
+    }
+
+    public function onSiteAccessMatch(PostSiteAccessMatchEvent $event): void
+    {
+        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id');
+        $this->urlAliasRouter->setRootLocationId($rootLocationId);
+        $this->urlAliasGenerator->setRootLocationId($rootLocationId);
+        $this->urlAliasGenerator->setExcludedUriPrefixes(
+            $this->configResolver->getParameter('content.tree_root.excluded_uri_prefixes')
+        );
+    }
+}

--- a/src/lib/Event/Subscriber/RoutingListener.php
+++ b/src/lib/Event/Subscriber/RoutingListener.php
@@ -10,6 +10,6 @@ namespace Ibexa\CompatibilityLayer\Event\Subscriber;
 
 use Ibexa\Bundle\Core\EventListener\RoutingListener as CoreRoutingListener;
 
-class RoutingListener extends CoreRoutingListener
+final class RoutingListener extends CoreRoutingListener
 {
 }


### PR DESCRIPTION
**JIRA**: [IBX-5929](https://issues.ibexa.co/browse/IBX-5929)

In the original `Ibexa\Bundle\Core\EventListener\RoutingListener` (`core` bundle) we are specifically injecting `@Ibexa\Bundle\Core\Routing\UrlAliasRouter`. This listener wasn't fired for `Ibexa\CompatibilityLayer\Routing\UrlAliasRouter`, so it has been added in the following PR.